### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *.swo
 .stack-work/
+stack.yaml.lock

--- a/HGE2D.cabal
+++ b/HGE2D.cabal
@@ -42,11 +42,11 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-      base >= 4.8.2.0 && < 5.0,
+      base >= 4.11 && < 5.0,
       OpenGL >=3.0 && < 3.1,
       GLUT >= 2.7 && < 2.8,
-      time >= 1.5.0.1 && < 1.7,
-      safe == 0.3.9
+      time >= 1.9 && < 1.10,
+      safe == 0.3.19
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2 -W -fwarn-incomplete-patterns -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.3
+resolver: lts-17.9
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
[src/HGE2D/Instances.hs](https://github.com/I3ck/HGE2D/blob/7ab789964013d8f24cd0be9fbad967d41d00a4bb/src/HGE2D/Instances.hs#L22-L23) uses Semigroup with was introduced in base-4.11.0.0. Because of this building examples with `stack` fails. I've bumped the resolver in `stack.yaml` (to the latest one) as well as some of the dependencies.